### PR TITLE
 Fix pypi trove classifiers (Robot Framework)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,5 @@ setuptools.setup(
         "Operating System :: Microsoft",
         'Topic :: Games/Entertainment :: Simulation',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Framework :: Robot Framework :: Tool'
     ]
 )


### PR DESCRIPTION
The [PyPi trove classifiers set in setup.cfg](https://github.com/sanitizers/octomachinery/blob/master/setup.cfg#L30-L32) reference classifiers which are meant to be used for the [Robot Framework](https://pypi.org/project/robotframework/).